### PR TITLE
Fix purchase history logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -180,6 +180,8 @@ async def announce_purchase(guild, user, pack):
             embed.set_image(url=pack["image_url"])
             await chan.send(embed=embed)
             break
+    # Stocke l'achat dans l'historique utilisateur
+    add_purchase_history(user.id, pack)
 
 # ───────────── HISTORIQUE DES ACHATS ─────────────
 


### PR DESCRIPTION
## Summary
- register volt purchases in user history after announcements

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684228bc4fbc832e995d2e9c6ce8cb21